### PR TITLE
Configured Steampipe to allow querying the local cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ Thumbs.db
 
 # Devbox
 .devbox
+
+# Steampipe
+.steampipe

--- a/.steampipe/config/kubernetes.spc
+++ b/.steampipe/config/kubernetes.spc
@@ -1,0 +1,71 @@
+connection "kubernetes" {
+  plugin = "kubernetes"
+
+  # By default, the plugin will use credentials in "~/.kube/config" with the current context.
+  # OpenID Connect (OIDC) authentication is supported without any extra configuration.
+  # The kubeconfig path and context can also be specified with the following config arguments:
+
+  # Specify the file path to the kubeconfig.
+  # Can also be set with the "KUBECONFIG" or "KUBE_CONFIG_PATH" environment variables. Plugin will prioritize KUBECONFIG if both are available.
+  # config_path = "~/.kube/config"
+
+  # Specify a context other than the current one.
+  # config_context = "minikube"
+
+  # List of custom resources that will be created as dynamic tables.
+  # No dynamic tables will be created if this arg is empty or not set.
+  # Wildcard based searches are supported.
+
+  # For example:
+  #  - "*" matches all custom resources available
+  #  - "*.storage.k8s.io" matches all custom resources in the storage.k8s.io group
+  #  - "certificates.cert-manager.io" matches a specific custom resource "certificates.cert-manager.io"
+  #  - "backendconfig" matches the singular name "backendconfig" in any group
+
+  # Defaults to all custom resources
+  custom_resource_tables = ["*"]
+
+  # If no kubeconfig file can be found, the plugin will attempt to use the service account Kubernetes gives to pods.
+  # This authentication method is intended for clients that expect to be running inside a pod running on Kubernetes.
+
+  # Specify the source(s) of the resource(s). Possible values: `deployed`, `helm` and `manifest`.
+  # Defaults to all possible values. Set the argument to override the default value.
+  # If `deployed` is contained in the value, tables will show all the deployed resources.
+  # If `helm` is contained in the value, tables will show resources from the configured helm charts.
+  # If `manifest` is contained in the value, tables will show all the resources from the kubernetes manifest. Make sure that the `manifest_file_paths` arg is set.
+  # source_types = ["deployed", "helm", "manifest"]
+
+  # Manifest File Configuration
+
+  # Manifest file paths is a list of locations to search for Kubernetes manifest files
+  # Manifest file paths can be configured with a local directory, a remote Git repository URL, or an S3 bucket URL
+  # Refer https://hub.steampipe.io/plugins/turbot/kubernetes#supported-path-formats for more information
+  # Wildcard based searches are supported, including recursive searches
+  # Local paths are resolved relative to the current working directory (CWD)
+
+  # For example:
+  #  - "*.yml" or "*.yaml" or "*.json" matches all Kubernetes manifest files in the CWD
+  #  - "**/*.yml" or "**/*.yaml" or "**/*.json" matches all Kubernetes manifest files in the CWD and all sub-directories
+  #  - "../*.yml" or "../*.yaml" or "../*.json" matches all Kubernetes manifest files in the CWD's parent directory
+  #  - "steampipe*.yml" or "steampipe*.yaml" or "steampipe*.json" matches all Kubernetes manifest files starting with "steampipe" in the CWD
+  #  - "/path/to/dir/*.yml" or "/path/to/dir/*.yaml" or "/path/to/dir/*.json" matches all Kubernetes manifest files in a specific directory
+  #  - "/path/to/dir/main.yml" or "/path/to/dir/main.yaml" or "/path/to/dir/main.json" matches a specific file
+
+  # If the given paths includes "*", all files (including non-kubernetes manifest files) in
+  # the CWD will be matched, which may cause errors if incompatible file types exist
+
+  # Defaults to CWD
+  # manifest_file_paths = [ "*.yml", "*.yaml", "*.json" ]
+
+  # Helm configuration
+
+  # A map for Helm charts along with the path to the chart directory and the paths of the value override files (if any).
+  # Every map should have chart_path defined, and the values_file_paths is optional.
+  # You can define multiple charts in the config.
+  # helm_rendered_charts = {
+  #   "chart_name" = {
+  #     chart_path        = "/path/to/chart/dir"
+  #     values_file_paths = ["/path/to/value/override/files.yaml"]
+  #   }
+  # }
+}

--- a/README.md
+++ b/README.md
@@ -32,3 +32,30 @@ Traefik is used as the ingress controller for the cluster.
 ##### Dashboard (Chart)
 
 The default K8 dashboard is deployed so that we can inspect the cluster.
+
+##### Steampipe
+
+[Steampipe](https://steampipe.io/) has been configured on the CLI. This makes
+it easy to query the cluster via SQL.
+
+You can either start the interactive shell using `devbox run steampipe` or run a
+query directly like the example below.
+
+```
+$ steampipe query "SELECT name FROM kubernetes_pod"
+
++-------------------------------------------------+
+| name                                            |
++-------------------------------------------------+
+| elastic-operator-0                              |
+| kube-scheduler-docker-desktop                   |
+| my-kibana-kb-786f98bfc9-v7x7w                   |
+| ts-tailscale-apm-ingress-v9qzc-0                |
+| filebeat-beat-filebeat-g66jc                    |
+| traefik-6f99669b8d-cxxbt                        |
+| ts-tailscale-dashboard-ingress-wz786-0          |
++-------------------------------------------------+
+```
+
+More information about querying Kubernetes via Steampipe can be found on the
+[associated plugin page](https://hub.steampipe.io/plugins/turbot/kubernetes).

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,17 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetpack-io/devbox/0.10.3/.schema/devbox.schema.json",
-  "packages": ["nodejs@20", "pulumi-bin@latest"],
+	"env": {
+		"STEAMPIPE_INSTALL_DIR": ".steampipe"
+	},
+	"packages": [
+    "nodejs@20",
+    "pulumi-bin@latest",
+    "steampipe@latest"
+  ],
   "shell": {
-    "init_hook": ["export $(xargs < .env)"]
+    "init_hook": [
+		"export $(xargs < .env)",
+		"steampipe plugin install kubernetes"
+	]
   }
 }

--- a/devbox.json
+++ b/devbox.json
@@ -1,17 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetpack-io/devbox/0.10.3/.schema/devbox.schema.json",
-	"env": {
-		"STEAMPIPE_INSTALL_DIR": ".steampipe"
-	},
-	"packages": [
-    "nodejs@20",
-    "pulumi-bin@latest",
-    "steampipe@latest"
-  ],
+  "env": {
+    "STEAMPIPE_INSTALL_DIR": ".steampipe"
+  },
+  "packages": ["nodejs@20", "pulumi-bin@latest", "steampipe@latest"],
   "shell": {
-    "init_hook": [
-		"export $(xargs < .env)",
-		"steampipe plugin install kubernetes"
-	]
+    "init_hook": ["export $(xargs < .env)"],
+    "scripts": {
+      "steampipe": ["steampipe plugin install kubernetes", "steampipe query"]
+    }
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -113,6 +113,54 @@
           "store_path": "/nix/store/198nxwll988a0a0n2jqa6p8w60n2g4g9-pulumi-3.138.0"
         }
       }
+    },
+    "steampipe@latest": {
+      "last_modified": "2024-12-23T21:10:33Z",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#steampipe",
+      "source": "devbox-search",
+      "version": "1.0.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3ycnsr6y9n3l6fjlaf7fxzvaarx6ndjh-steampipe-1.0.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3ycnsr6y9n3l6fjlaf7fxzvaarx6ndjh-steampipe-1.0.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ip45y7jfdi095cvs8q1nwbllb1xxazdg-steampipe-1.0.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ip45y7jfdi095cvs8q1nwbllb1xxazdg-steampipe-1.0.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ppiiamnsqxyb6bkbnil3z60f18wivxsk-steampipe-1.0.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ppiiamnsqxyb6bkbnil3z60f18wivxsk-steampipe-1.0.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/s7h7ik8kzqck3fh3bw0nhlr0cb23bfiw-steampipe-1.0.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/s7h7ik8kzqck3fh3bw0nhlr0cb23bfiw-steampipe-1.0.1"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Configured Steampipe to allow querying the local cluster

## Description

Updated the Devbox configuration to install Steampipe and configure it to use a local directory.

## Related Issue

#7 

## Motivation and Context

It allows you to query the Kubernetes cluster using SQL. While this doesn't improve the actual cluster-config in any way, it does make it easier to query it.

## How Has This Been Tested?

Manually.

## Documentation:

In the Readme.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
